### PR TITLE
Use azd binding feature to connect to services

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/houk-ms/azure-dev/bindings/schemas/alpha/azure.yaml.json
 
 name: todo-nodejs-mongo-aca
 metadata:
@@ -7,6 +7,7 @@ workflows:
   up: 
     steps:
       - azd: provision
+      - azd: binding api
       - azd: deploy --all
 services:
   web:
@@ -17,6 +18,14 @@ services:
     project: ./src/api
     language: js
     host: containerapp
+    bindings:
+      - name: api2cosmos
+        targetType: cosmos
+        targetResource: cosmosaccount
+      - name: api2appinsight
+        targetType: app-insights
+        targetResource: appinsight
+
 # using predeploy hook for web until
 # https://github.com/Azure/azure-dev/issues/3546 is fixed
 hooks:
@@ -28,7 +37,8 @@ hooks:
   predeploy:
     windows:
       shell: pwsh
-      run: 'echo "VITE_API_BASE_URL=\"$env:API_BASE_URL\"" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$env:APPLICATIONINSIGHTS_CONNECTION_STRING\"" >> ./src/web/.env.local'
+      # BUG: the escape character \ is not working and still in the env.local file. So The env value is correct.
+      run: 'echo "VITE_API_BASE_URL=$env:API_BASE_URL" > ./src/web/.env.local ; echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=$env:APPLICATIONINSIGHTS_CONNECTION_STRING" >> ./src/web/.env.local'
     posix:
       shell: sh
       run: 'echo VITE_API_BASE_URL=\"$API_BASE_URL\" > ./src/web/.env.local && echo VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" >> ./src/web/.env.local'    

--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -3,11 +3,11 @@ param location string = resourceGroup().location
 param tags object = {}
 
 param identityName string
-param applicationInsightsName string
 param containerAppsEnvironmentName string
 param containerRegistryName string
 param containerRegistryHostSuffix string
 param keyVaultName string
+param appConfigName string
 param serviceName string = 'api'
 param corsAcaUrl string
 param exists bool
@@ -22,6 +22,15 @@ module apiKeyVaultAccess '../core/security/keyvault-access.bicep' = {
   name: 'api-keyvault-access'
   params: {
     keyVaultName: keyVaultName
+    principalId: apiIdentity.properties.principalId
+  }
+}
+
+// Give the API access to App Configuration. Role assignment after both created otherwise mutual dependency.
+module appConfigurationAccess '../core/security/configstore-access.bicep' = {
+  name: 'app-configuration-access'
+  params: {
+    configStoreName: appConfiguratoin.name
     principalId: apiIdentity.properties.principalId
   }
 }
@@ -51,8 +60,8 @@ module app '../core/host/container-app-upsert.bicep' = {
         value: keyVault.properties.vaultUri
       }
       {
-        name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-        value: applicationInsights.properties.ConnectionString
+        name: 'AZURE_APPCONFIGURATION_ENDPOINT'
+        value: appConfiguratoin.properties.endpoint
       }
       {
         name: 'API_ALLOW_ORIGINS'
@@ -63,12 +72,13 @@ module app '../core/host/container-app-upsert.bicep' = {
   }
 }
 
-resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
-  name: applicationInsightsName
-}
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
+}
+
+resource appConfiguratoin 'Microsoft.AppConfiguration/configurationStores@2023-03-01' existing = {
+  name: appConfigName
 }
 
 output SERVICE_API_IDENTITY_PRINCIPAL_ID string = apiIdentity.properties.principalId

--- a/infra/app/db.bicep
+++ b/infra/app/db.bicep
@@ -38,3 +38,4 @@ module cosmos '../core/database/cosmos/mongo/cosmos-mongo-db.bicep' = {
 output connectionStringKey string = cosmos.outputs.connectionStringKey
 output databaseName string = cosmos.outputs.databaseName
 output endpoint string = cosmos.outputs.endpoint
+output accountName string = accountName

--- a/infra/core/config/configstore.bicep
+++ b/infra/core/config/configstore.bicep
@@ -15,8 +15,6 @@ param keyValueNames array = []
 @description('Specifies the values of the key-value resources.')
 param keyValueValues array = []
 
-@description('The principal ID to grant access to the Azure App Configuration store')
-param principalId string
 
 resource configStore 'Microsoft.AppConfiguration/configurationStores@2023-03-01' = {
   name: name
@@ -36,13 +34,6 @@ resource configStoreKeyValue 'Microsoft.AppConfiguration/configurationStores/key
   }
 }]
 
-module configStoreAccess '../security/configstore-access.bicep' = {
-  name: 'app-configuration-access'
-  params: {
-    configStoreName: name
-    principalId: principalId
-  }
-  dependsOn: [configStore]
-}
 
 output endpoint string = configStore.properties.endpoint
+output name string = name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -21,6 +21,7 @@ param containerRegistryName string = ''
 param cosmosAccountName string = ''
 param cosmosDatabaseName string = ''
 param keyVaultName string = ''
+param appConfigName string = ''
 param logAnalyticsName string = ''
 param resourceGroupName string = ''
 param webContainerAppName string = ''
@@ -103,11 +104,11 @@ module api './app/api.bicep' = {
     location: location
     tags: tags
     identityName: '${abbrs.managedIdentityUserAssignedIdentities}api-${resourceToken}'
-    applicationInsightsName: monitoring.outputs.applicationInsightsName
     containerAppsEnvironmentName: containerApps.outputs.environmentName
     containerRegistryName: containerApps.outputs.registryName
     containerRegistryHostSuffix: containerRegistryHostSuffix
     keyVaultName: keyVault.outputs.name
+    appConfigName: appConfig.outputs.name
     corsAcaUrl: corsAcaUrl
     exists: apiAppExists
   }
@@ -135,6 +136,17 @@ module keyVault './core/security/keyvault.bicep' = {
     location: location
     tags: tags
     principalId: principalId
+  }
+}
+
+// App Configuration infra for service connector bindings
+module appConfig './core/config/configstore.bicep' = {
+  name: 'appConfig'
+  scope: rg
+  params: {
+    name: !empty(appConfigName) ? appConfigName :'${abbrs.appConfigurationStores}${resourceToken}'
+    location: location
+    tags: tags
   }
 }
 
@@ -200,3 +212,12 @@ output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME
 output SERVICE_WEB_NAME string = web.outputs.SERVICE_WEB_NAME
 output USE_APIM bool = useAPIM
 output SERVICE_API_ENDPOINTS array = useAPIM ? [ apimApi.outputs.SERVICE_API_URI, api.outputs.SERVICE_API_URI ]: []
+
+// API bindings common
+output AZURE_RESOURCE_GROUP string = rg.name
+// output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME
+output BINDING_STORE_NAME string = appConfig.outputs.name
+// API to Cosmos bindings
+output BINDING_RESOURCE_COSMOSACCOUNT string = cosmos.outputs.accountName
+// API to AppInsights bindings
+output BINDING_RESOURCE_APPINSIGHT string = monitoring.outputs.applicationInsightsName

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -215,9 +215,18 @@ output SERVICE_API_ENDPOINTS array = useAPIM ? [ apimApi.outputs.SERVICE_API_URI
 
 // API bindings common
 output AZURE_RESOURCE_GROUP string = rg.name
+
+// Source resource API
 // output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME
+
+// Default Configuration Store
 output BINDING_STORE_NAME string = appConfig.outputs.name
+
+// Default KeyVault Secret Store
+output BINDING_SECRET_KEYVAULT string = keyVault.outputs.name
+
 // API to Cosmos bindings
 output BINDING_RESOURCE_COSMOSACCOUNT string = cosmos.outputs.accountName
+
 // API to AppInsights bindings
 output BINDING_RESOURCE_APPINSIGHT string = monitoring.outputs.applicationInsightsName

--- a/src/api/config/custom-environment-variables.json
+++ b/src/api/config/custom-environment-variables.json
@@ -1,6 +1,6 @@
 {
     "database": {
-        "connectionString": "AZURE_COSMOS_CONNECTION_STRING",
+        "connectionString": "AZURE_COSMOS_API2COSMOS_CONNECTIONSTRING",
         "databaseName": "AZURE_COSMOS_DATABASE_NAME"
     },
     "observability": {

--- a/src/api/package-lock.json
+++ b/src/api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@azure/app-configuration": "1.5.0",
         "@azure/identity": "4.0.1",
         "@azure/keyvault-secrets": "^4.7.0",
         "applicationinsights": "^2.5.1",
@@ -793,6 +794,27 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/app-configuration": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.5.0.tgz",
+      "integrity": "sha512-YlXwWc/weDFCk12arPkfskXDGxDaSyAA7JaztSVQ0y/IS7GFYqmIj3RTKbsNUSSuGLrKqcxwJ7y3vY9UmHgsdA==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.5.0",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^2.5.1",
+        "@azure/core-paging": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.6.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.1.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-auth": {

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -24,6 +24,7 @@
     ]
   },
   "dependencies": {
+    "@azure/app-configuration": "1.5.0",
     "@azure/identity": "4.0.1",
     "@azure/keyvault-secrets": "^4.7.0",
     "applicationinsights": "^2.5.1",


### PR DESCRIPTION
Reference azd PR for binding feature: https://github.com/Azure/azure-dev/pull/3549, This is a code demo to utilize the new azd feature `binding` :
- Use bindings in azure.yaml to define Service Connectors
- Service Connector configures ConnectionStrings of CosmosDb, ApplicationInsight into an extra Azure App Configuration instance.
- API node.js code consumes the ConnectionStrings from App Configuration.
- KeyVault and AppConfigurations works as the infra for reading connetion string, so they still have endpoint in environment variables, with a user-assigned managed identity having rbac role assignment to access these secrets/configuraitons